### PR TITLE
gs-1017-recreate-manifests-with-cli-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ Thinkific NPM Tool
 * You'll need a thinkific API V1 key
 * Run `thinkcli` and you should be able to continue from there
 
+### Recreating manifests
+There is a configuration option, `recreate_manifests`, which defaults to false. When this option is true, it will delete and recreate any manifests that are affected by a change. This means you can change default values in a schema and have these take immediate affect on your site via the sync. If the configuration is false, changing a default value would not override the existing value in a manifest and therefore not take affect on your site.
+
+To change this configuration, you need to manually update your `~/.thinkific_config` file. e.g.
+
+```
+{
+  "api_key": "xxx",
+  "subdomain": "my-school",
+  "path": "/Users/ianmooney/Thinkific/themes",
+  "env": "production",
+  "recreate_manifests": true,
+  "themes": {
+    "1900": "horizon/src"
+  }
+}
+
+```
+
+**BEWARE:** This configuration is destructive and can permanently delete existing content on a theme, so only use on test themes.
+
 # Know issues
 * Help message isn't very friendly eg. `thinkcli themes <subcommand:list|download> <theme_id>`
 * As it is at the moment, the sync is strict. Nothing should happen to the theme when sync command

--- a/src/commands/wizard.js
+++ b/src/commands/wizard.js
@@ -71,6 +71,7 @@ const setup = () => {
       print(chalk.red(err));
     } else {
       _responses.env = 'production';
+      _responses.recreate_manifests = false;
       _responses.themes = credentials.themes || {};
       configHelpers.setConfigData(responses, () => {
         print(chalk.green('\nCredentials saved\n'));

--- a/src/helpers/request.js
+++ b/src/helpers/request.js
@@ -1,7 +1,7 @@
 const DOMAINS = {
   test: 'localhost:3000',
   local: 'school.lvh.me:3000',
-  staging: 'thinkific-staging.com',
+  staging: 'api.thinkific-staging.com',
   production: 'api.thinkific.com',
 }
 const API_PREFIX = 'api/public';

--- a/src/services/custom-site-theme-view.js
+++ b/src/services/custom-site-theme-view.js
@@ -2,7 +2,9 @@
 let request = require('../base/request'); // eslint-disable-line prefer-const
 const themeHelpers = require('../helpers/themes')
 const fs = require('fs');
+const configHelper = require('../helpers/config');
 
+const config = configHelper.getConfigData();
 const BASE = 'custom_site_theme_views';
 
 const formulatePostData = (themeId, filename) => {
@@ -10,6 +12,7 @@ const formulatePostData = (themeId, filename) => {
   const content = fs.readFileSync(filename);
   return {
     form: {
+      recreate_manifests: config.recreate_manifests,
       theme_id: themeId,
       path: resource,
       content,

--- a/test/helpers/themes.spec.js
+++ b/test/helpers/themes.spec.js
@@ -1,8 +1,6 @@
 const should = require('should');
 const configHelpers = require('../../src/helpers/themes.js');
 
-console.log(configHelpers);
-
 describe('theme Helpers', () => {
   describe('isHiddenFile', () => {
     it('considers .dir/file hidden', () => {


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/377885080459802/388381874944859)

This PR introduces a new configuration option, `recreate_manifests`, which will get included in the POST request that happens when a file is edited. If set to true, it will mean that all manifests that are affected by the change will get deleted and recreated. This means that any default values or default blocks will be generated and can be viewed immediately.

Corresponding Rails PR - https://github.com/thinkific/thinkific/pull/5851