### PR TITLE
gs-1067-handle-manifest-json-in-cli-tool

### DIFF
--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -3,8 +3,14 @@ let fs = require('fs'); // eslint-disable-line prefer-const
 
 const configFile = '.thinkific_config';
 
-let getConfigPath = () =>  // eslint-disable-line prefer-const
-   path.resolve(process.env.HOME, configFile)
+
+let getConfigPath = () =>  { // eslint-disable-line prefer-const
+  if (process.env.NODE_ENV == 'test') {
+    return path.resolve(process.env.PWD, 'test', configFile);
+  } else {
+    return path.resolve(process.env.HOME, configFile);
+  }
+}
 
 const getConfigData = () => {
   // load previous credentials (if applicable)

--- a/src/services/sync.js
+++ b/src/services/sync.js
@@ -1,6 +1,7 @@
 const chokidar = require('chokidar');
 const path = require('path');
 const chalk = require('chalk');
+const themeService = require('../services/themes');
 const customSiteThemeViewService = require('../services/custom-site-theme-view');
 const assetService = require('../services/asset');
 const themesHelpers = require('../helpers/themes');
@@ -13,7 +14,7 @@ const syncFile = (eventType, themeId, themePath, filename) => {
     print(chalk.yellow(`${resource}: Ignoring hidden file\n`));
     return;
   }
-  const service = resource.startsWith('assets') ? assetService : customSiteThemeViewService;
+  const service = fetchService(resource);
   switch (eventType) {
     case 'add':
       print(chalk.green(`${resource}: Creating File!\n`));
@@ -53,6 +54,16 @@ const syncFile = (eventType, themeId, themePath, filename) => {
       break;
   }
 };
+
+const fetchService = (resource) => {
+  if (resource == 'manifest.json') {
+    return themeService;
+  } else if (resource.startsWith('assets')) {
+    return assetService;
+  } else {
+    return customSiteThemeViewService;
+  }
+}
 
 const run = (themeId) => {
   const config = configHelpers.getConfigData();

--- a/src/services/themes.js
+++ b/src/services/themes.js
@@ -1,14 +1,12 @@
 // we want to unit the functions in this module
 let request = require('../base/request'); // eslint-disable-line prefer-const
-const themeHelpers = require('../helpers/themes')
-const fs = require('fs');
+let fs = require('fs'); // eslint-disable-line prefer-const
 const configHelper = require('../helpers/config');
 
 const config = configHelper.getConfigData();
 const BASE = 'custom_site_themes';
 
 const formulatePutData = (themeId, filename) => {
-  const resource = themeHelpers.getResourcePath(themeId, filename);
   const content = fs.readFileSync(filename);
   return {
     form: {

--- a/src/services/themes.js
+++ b/src/services/themes.js
@@ -1,7 +1,23 @@
 // we want to unit the functions in this module
 let request = require('../base/request'); // eslint-disable-line prefer-const
+const themeHelpers = require('../helpers/themes')
+const fs = require('fs');
+const configHelper = require('../helpers/config');
 
+const config = configHelper.getConfigData();
 const BASE = 'custom_site_themes';
+
+const formulatePutData = (themeId, filename) => {
+  const resource = themeHelpers.getResourcePath(themeId, filename);
+  const content = fs.readFileSync(filename);
+  return {
+    form: {
+      recreate_manifests: config.recreate_manifests,
+      theme_id: themeId,
+      manifest_schema: content,
+    },
+  };
+};
 
 const get = (callback) => {
   request.get(BASE, (err, data) => {
@@ -13,6 +29,13 @@ const get = (callback) => {
   });
 }
 
+const put = (themeId, filename, callback) => {
+  request.put(`${BASE}/${themeId}`, formulatePutData(themeId, filename), (err, response) => {
+    callback(err, response);
+  });
+}
+
 module.exports = {
   get,
+  put,
 }

--- a/test/.thinkific_config
+++ b/test/.thinkific_config
@@ -1,0 +1,10 @@
+{
+  "api_key": "abc123",
+  "subdomain": "school",
+  "path": "/Users/ianmooney/Thinkific/themes",
+  "env": "test",
+  "recreate_manifests": true,
+  "themes": {
+    "123": "horizon/src"
+  }
+}

--- a/test/services/themes.spec.js
+++ b/test/services/themes.spec.js
@@ -8,7 +8,7 @@ describe('themes service', () => {
     should.exist(service);
   });
 
-  it('with a get wrapper to get custom site themes', () => {
+  it('provides a get wrapper to get custom site themes', () => {
     const retrievedData = { custom_site_themes: { hello: 'world' } };
     const request = {
       get: (base, callback) => {
@@ -20,6 +20,38 @@ describe('themes service', () => {
     service.get((err, data) => {
       should.not.exist(err);
       should(data).equal(retrievedData.custom_site_themes);
+    });
+  });
+
+  it('provides a put wrapper to update a custom site theme', () => {
+    const themeId = '123';
+    const filename = 'pages/home_landing_page.liquid';
+    const retrievedData = { custom_site_theme: { hello: 'world' } };
+    const fs = {
+      readFileSync: (filenameReceived) => {
+        filenameReceived.should.equal(filename);
+        return 'MANIFEST SCHEMA';
+      },
+    };
+    const request = {
+      put: (base, formData, callback) => {
+        base.should.equal('custom_site_themes/' + themeId);
+        let expectedFormData = {
+          form: {
+            recreate_manifests: true,
+            theme_id: themeId,
+            manifest_schema: 'MANIFEST SCHEMA',
+          }
+        };
+        should(formData == expectedFormData).be.ok;
+        callback(null, retrievedData);
+      },
+    };
+    service.__set__('fs', fs);
+    service.__set__('request', request);
+    service.put(themeId, filename, (err, data) => {
+      should.not.exist(err);
+      should(data).equal(retrievedData);
     });
   });
 


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/377885080459802/394729984042471)

Use `PUT custom_site_themes/[theme_id]` action to update a theme's manifest when a change to `manifest.json` is detected. If `recreate_manifests` option is true, the whole theme manifest is updated, otherwise only new settings are added to it.

Corresponding Rails PR https://github.com/thinkific/thinkific/pull/5881